### PR TITLE
add workaround for home directory creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ However, we provide a few scripts in this repository to make your life easier to
 ```bash
 python csub.py -n sandbox -g 1 -t 7d -i ic-registry.epfl.ch/mlo/mlo:v1 --command "cd /mloscratch/homes/<your username>; pip install jupyter && jupyter notebook"
 ```
+> [!NOTE]  
+> If the pod creation fails saying `mkdir: cannot create directory '/mloscratch/homes/<your username>': Permission denied`, try creating the directory manually by
+> ```bash
+> ssh <your username>@haas001.rcp.epfl.ch
+> mkdir /mnt/mlo/scratch/homes/<your username>
+> ```
+> and then try again. 
 
 4. Wait until the pod has a 'running' status -- this can take a bit (max ~5 min or so). Check the status of the job with 
 ```bash


### PR DESCRIPTION
There seems to be a problem with running the `csub.py` script for first time users - the script fails due to not having permissions to create the `mloscratch/homes/$GASPAR_USERNAME` directory.

A workaround is to manually `ssh` into the IT machine and create the directory, and then to run the script again. 

I added it to the readme for future readers :)